### PR TITLE
Remove command list.

### DIFF
--- a/examples/cmd_list.txt
+++ b/examples/cmd_list.txt
@@ -1,5 +1,0 @@
-1. Build instrumented test bin:
-
-go test ./examples/echo-arg/... -tags testbincover -coverpkg=./... -c -o examples/echo-arg/instr_bin -ldflags="-X github.com/confluentinc/bincover/examples/echo-arg.isTest=true"
-
-


### PR DESCRIPTION
Remove unnecessary command list file. This was originally supposed to be a list of useful commands you could run, but the only command in there is now in the `echo-arg` example directory.