### PR TITLE
Upgrade golangci-lint to v1.31.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO              ?= go
 ifdef TF_BUILD
 	CI := on
 endif
-GOLANGCI_LINT_VERSION := v1.21.0
+GOLANGCI_LINT_VERSION := v1.31.0
 
 all: test
 


### PR DESCRIPTION
For some reason v1.21.0 (the current version) exits with a 0 exit code when it encounters a lint error, like an unhandled error in the code. Upgrading to the current version fixes that.